### PR TITLE
Enhancement #10 download UI update

### DIFF
--- a/apps/web-app/app/view/page.tsx
+++ b/apps/web-app/app/view/page.tsx
@@ -12,7 +12,12 @@ export interface video {
 export default function Home() {
 	const [videos, setVideos] = useState<any>([]);
 	const [output, setOutput] = useState<string>("");
-	const [activePreview, setActivePreview] = useState<any>({});
+	// const [activePreview, setActivePreview] = useState<any>({});
+
+	const [outputType, setOutputType] = useState<string>(""); // Tracks the output type
+	const [activeVideo, setActiveVideo] = useState<any>({}); // Tracks the active video
+
+
 	useEffect(() => {
 		async function fetchVideos() {
 			const res = await fetch("./api/videos");
@@ -30,6 +35,49 @@ export default function Home() {
 		setOutput(data);
 	}
 
+
+	function handleDownload() {
+		if (!output || !outputType || !activeVideo.title) return;
+
+		let fileName;
+		let fileType;
+		let fileContent;
+
+		switch (outputType) {
+			case "Captions":
+				fileName = `${activeVideo.title}-captions.vtt`;
+				fileType = "text/vtt";
+				fileContent = output;
+				break;
+			case "Transcription":
+				fileName = `${activeVideo.title}-transcription.txt`;
+				fileType = "text/plain";
+				fileContent = output;
+				break;
+			case "Chapters":
+				fileName = `${activeVideo.title}-chapters.json`;
+				fileType = "application/json";
+				fileContent = JSON.stringify(output, null, 2); // Beautify JSON
+				break;
+			default:
+				return;
+		}
+
+		// Create a blob with the content
+		const blob = new Blob([fileContent], { type: fileType });
+		const url = URL.createObjectURL(blob);
+
+		// Create an anchor element and trigger a download
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = fileName;
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+
+		// Revoke the URL after the download
+		URL.revokeObjectURL(url);
+	}
 	return (
 		<main className="w-screen h-screen grid grid-cols-12 p-4 gap-8">
 			<div className="col-span-6 flex flex-col justify-start items-center p-4">
@@ -40,7 +88,13 @@ export default function Home() {
 							video.failed ? (
 								<ErrorCard key={video._id} video={video} />
 							) : (
-								<SuccessCard setOutput={setOutput} key={video._id} video={video} />
+								<SuccessCard
+									key={video._id}
+									video={video}
+									setOutput={setOutput}
+									setOutputType={setOutputType}
+									setActiveVideo={setActiveVideo}
+								/>
 							)
 						)}
 				</div>
@@ -48,6 +102,12 @@ export default function Home() {
 			<div className="col-span-6 flex flex-col justify-start items-center p-4">
 				<h1 className="py-8 text-lg font-bold">Preview</h1>
 				<div>{output}</div>
+				{/* if there is output */}
+				{output && (
+					<Button className="mt-4" onClick={handleDownload}>
+						Download {outputType}
+					</Button>
+				)}
 			</div>
 		</main>
 	);
@@ -63,7 +123,7 @@ const ErrorCard = ({ video }) => (
 	</div>
 );
 
-const SuccessCard = ({ video, setOutput }) => (
+const SuccessCard = ({ video, setOutput, setOutputType, setActiveVideo }) => (
 	<div key={video._id} className="relative border p-8 min-w-full min-h-[100px]">
 		<div className="border-b font-bold pb-2 tracking-wide">{video.title}</div>
 		<div className="p-4 h-full flex gap-4 justify-center items-center w-full">
@@ -74,17 +134,43 @@ const SuccessCard = ({ video, setOutput }) => (
 				</video>
 			</div>
 			<div className="flex flex-col justify-center items-center gap-4">
-				<Button size="sm" className="w-[160px]" onClick={() => setOutput(video.captions)}>
+				<Button
+					size="sm"
+					className="w-[160px]"
+					onClick={() => {
+						setOutput(video.captions);
+						setOutputType("Captions");
+						setActiveVideo(video);
+					}}
+				>
 					Captions
 				</Button>
-				<Button size="sm" className="w-[160px]" onClick={() => setOutput(video.transcription)}>
+				<Button
+					size="sm"
+					className="w-[160px]"
+					onClick={() => {
+						setOutput(video.transcription);
+						setOutputType("Transcription");
+						setActiveVideo(video);
+					}}
+				>
 					Transcription
 				</Button>
-				<Button size="sm" className="w-[160px]" onClick={() => setOutput(video.chapters)}>
+				<Button
+					size="sm"
+					className="w-[160px]"
+					onClick={() => {
+						setOutput(video.chapters);
+						setOutputType("Chapters");
+						setActiveVideo(video);
+					}}
+				>
 					Chapters
 				</Button>
 			</div>
 		</div>
-		<div className="absolute top-4 right-6 px-4 py-2 rounded-full bg-green-200 border">Success</div>
+		<div className="absolute top-4 right-6 px-4 py-2 rounded-full bg-green-200 border">
+			Success
+		</div>
 	</div>
 );


### PR DESCRIPTION
**Description:**
This PR addresses and closes issue #10, which requested the ability to download video-related outputs (transcriptions, subtitles, and chapters) as files directly from the preview section.

**Changes Introduced:**
--Added a download button in the preview section that dynamically enables users to download content based on their current selection (transcription, chapters, or subtitles).

The file download format and naming conventions are as follows:
--Transcriptions: [video-title]-transcript.txt
--Chapters: [video-title]-chapters.json
--Subtitles: [video-title]-subtitles.vtt


The functionality is integrated into the video preview area where users can:
View video transcriptions, chapters, or subtitles.
Download the respective content with a single click.